### PR TITLE
feature/return: add ability to return iCal contents via use of a new …

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ A Craft CMS plugin that implements [eluceo/iCal](https://github.com/eluceo/iCal)
 
 ### `render`
 
-The plugin includes a single Twig variable, `render`, which accepts an array/object of parameters to render the iCal event.
+The plugin includes a single Twig variable, `render`, which accepts an array/object of parameters to render the iCal event, and an optional boolean indicating whether to force-download and exit, or return the iCal contents.
+
+Specifying the boolean allows you to use the results elsewhere in your Craft plugins, e.g.:
+
+    use \Craft\PlainIcsVariable as PlainIcsVariable;
+    $results = PlainIcsVariable::render($params, true);
 
 #### Parameters
 

--- a/variables/PlainIcsVariable.php
+++ b/variables/PlainIcsVariable.php
@@ -6,12 +6,16 @@ class PlainIcsVariable
 
     /**
      * Render and force-download an .ics file
-     * built from the passed in parameters array.
+     * built from the passed in parameters array
+     * if $return is not true.
+     * If $return is true, we'll simply return the
+     * .ics contents built from the passed in parameters array.
      *
      * @param array $parameters
+     * @param string $return
      * @return exit
      */
-    public function render($parameters = null)
+    public function render($parameters = null, $return = false)
     {
         // Require a non-null array of parameters.
         if (is_null($parameters) || !is_array($parameters)) {
@@ -30,6 +34,11 @@ class PlainIcsVariable
 
         // Set the filename for the .ics file.
         $filename = isset($event->filename) && !empty($event->filename) ? $event->filename : 'cal.ics';
+
+        if ($return) {
+            // Render the .ics file.
+            return $event->ical()->render();
+        }
 
         // Set headers.
         header('Content-Type: text/calendar; charset=utf-8');


### PR DESCRIPTION
A small change, passing a boolean $return to the render method, which allows the caller to avoid the default force-download functionality, and instead retrieve the rendered iCal for further processing.

The use case for this is for allowing another Craft plugin to call this plugin, and then do something further with the iCal results, such as write it to a tmp file which can be attached to an email message.